### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
   "module": "dist/bigr.esm.js",
   "browser": "dist/bigr.umd.js",
   "browsermin": "dist/bigr.min.umd.js",
+  "exports": {
+    "import": "./dist/bigr.esm.js",
+    "require": "./dist/bigr.cjs.js"
+  },
   "scripts": {
     "lint": "npx eslint src",
     "test": "jest",


### PR DESCRIPTION
The `module` option is not used anymore.
Prefer the `exports` syntax for modern versions of Node.js.

See [here](https://nodejs.org/api/packages.html#conditional-exports)